### PR TITLE
fix API compatibility with firefox web extention

### DIFF
--- a/background.js
+++ b/background.js
@@ -39,7 +39,7 @@ function onRequest(request, sender, sendResponse) {
 };
 
 // Listen for the content script to send a message to the background page.
-chrome.extension.onRequest.addListener(onRequest);
+chrome.runtime.onMessage.addListener(onRequest);
 
 var next_fetch_at = 0;
 // sync db from api server


### PR DESCRIPTION
主要是換掉2個舊的Chrome API，
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/extension/onRequest
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onMessage

相容Firefox web-extension, 以後就可以用同份code 發佈到 Firefox Addon.

因為我不知道怎樣測，所以Patch還沒測過，@racklin @ronnywang 有什麼平常用來測試的假新聞連結嗎？