### PR TITLE
add some info into manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Download
 --------
 * [Chrome 瀏覽器擴充元件](https://chrome.google.com/webstore/detail/%E6%96%B0%E8%81%9E%E5%B0%8F%E5%B9%AB%E6%89%8B/hkenpfplphndcndhhhldecaammpmopoc)
-* [Firefox 瀏覽器擴充元件](https://addons.mozilla.org/zh-TW/firefox/addon/newshelper-firefox/)
+* [Firefox 瀏覽器擴充元件](https://addons.mozilla.org/zh-TW/firefox/addon/newshelper/)
 
 
 Backend

--- a/background.js
+++ b/background.js
@@ -256,8 +256,7 @@ var add_notification = function(title, body, link){
 
   if(!window.Notification) return;
 
-  var notification = new Notification(title, { icon: "newshelper48x48.png", body: body });
-
+  var notification = new Notification('' + title, { icon: "newshelper48x48.png", body: '' + body });
   notification.onclick = function(){
     window.open(link);
   };

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,17 @@
 {
+  "applications": {
+    "gecko": {
+      "id": "newshelper@g0v.tw",
+      "strict_min_version": "51.0"
+    }
+  },
+
   "manifest_version": 2,
 
   "name": "新聞小幫手",
   "description": "協助您判別含有誤導資訊的新聞",
   "version": "1.0.8",
-
+  "author": "ronnywang@gmail.com, wildsky@moztw.org, racklin@gmail.com",
   "permissions": [
     "notifications",
     "http://newshelper.g0v.tw/*",
@@ -23,15 +30,15 @@
   },
 
   "web_accessible_resources" : [
-    "lib/url-normalizer.js/map.csv"
+    "libs/url-normalizer.js/map.csv"
   ],
   "content_scripts" : [
     {
       "matches": [
         "http://www.facebook.com/*",
         "https://www.facebook.com/*",
-	"http://*/*",
-	"https://*/*"
+        "http://*/*",
+        "https://*/*"
       ],
       "js": [
         "jquery-3.2.1.min.js",
@@ -44,6 +51,19 @@
       "all_frames" : false
     }
   ],
+
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/g0v/newshelper-extension.git"
+  },
+  "bugs": {
+    "url": "https://github.com/g0v/newshelper-extension/issues"
+  },
+  "keywords": [
+    "newshelper",
+    "g0v-tw"
+  ],
+
   "icons" : {
      "128" : "newshelper128x128.png",
      "96" : "newshelper96x96.png",

--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,9 @@
 
   "manifest_version": 2,
 
-  "name": "新聞小幫手",
+  "name": "newshelper",
   "description": "協助您判別含有誤導資訊的新聞",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "author": "ronnywang@gmail.com, wildsky@moztw.org, racklin@gmail.com",
   "permissions": [
     "notifications",

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,8 @@
     }
   ],
 
+  "homepage_url": "https://addons.mozilla.org/zh-TW/firefox/addon/newshelper/",
+
   "repository": {
     "type": "git",
     "url": "git://github.com/g0v/newshelper-extension.git"


### PR DESCRIPTION
讓他能同時跑在 firefox 上，
cc @racklin  因為 firefox 換成 web-extension 架構了，所以 chrome 的套件也可以吃，
個人覺得不分開 repo 統一支援會比較好。


test
```
npm i -g web-ext
web-ext run -u https://www.facebook.com/新聞小幫手測試專用-494676360619618 
```
